### PR TITLE
Change hh_autoload.json to work in other codebases

### DIFF
--- a/hh_autoload.json
+++ b/hh_autoload.json
@@ -3,11 +3,7 @@
         "src/"
     ],
     "devRoots": [
-        "tests/",
-        "vendor/composer/facebook/",
-        "vendor/composer/hhvm/",
-        "vendor/composer/phpunit/",
-        "vendor/composer/sebastian/exporter/"
+        "tests/
     ],
     "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler"
 }


### PR DESCRIPTION
When you don't set a custom vendor-dir to `vendor/composer`, you couldn't run the autoloader.
This work with the default vendor-dir of vendor/.