### PR TITLE
Hhvm 3.30.12 compat

### DIFF
--- a/DEVELOPERNOTES.md
+++ b/DEVELOPERNOTES.md
@@ -12,7 +12,7 @@ Fatal error: Uncaught Error: Class undefined: Facebook\AutoloadMap\IncludedRoots
 ### Typechecker
 
 Composer requires two versions of the hsl and hsl-experimental that both define SecureRandom.
-Delete the file in /vendor/hhvm/hsl-experimetal/src/random/*.php
+Delete the file in /vendor/hhvm/hsl-experimetal/src/random/\*.php
 
 In vendor/hhvm/hhast/src/__Private/LintRun.php
 HHAST checks the truthyness of a traversable, vec($errors) first on line 105, like so.

--- a/DEVELOPERNOTES.md
+++ b/DEVELOPERNOTES.md
@@ -14,7 +14,7 @@ Fatal error: Uncaught Error: Class undefined: Facebook\AutoloadMap\IncludedRoots
 Composer requires two versions of the hsl and hsl-experimental that both define SecureRandom.
 Delete the file in /vendor/hhvm/hsl-experimetal/src/random/\*.php
 
-In vendor/hhvm/hhast/src/__Private/LintRun.php
+In vendor/hhvm/hhast/src/\_\_Private/LintRun.php
 HHAST checks the truthyness of a traversable, vec($errors) first on line 105, like so.
 ```
 $errors = await $linter->getLintErrorsAsync();
@@ -22,7 +22,7 @@ $errors = vec($errors);
 ```
 
 In vendor/facebook/fbexpect/src/ExpectObj.php
-fbexpect toBePHPEqualWithNANEqual uses is_float, instead of `is float`, so is_nan() is a type error, use `is float` on line 83, like so.
+fbexpect toBePHPEqualWithNANEqual uses is\_float, instead of `is float`, so is\_nan() is a type error, use `is float` on line 83, like so.
 ```
 is_float($expected) &&
 $actual is float &&
@@ -33,7 +33,7 @@ $actual is float &&
 ### Runtime
 
 In vendor/hhvm/hhast/src/SchemaVersionError.php
-HHAST divides your HHVM_VERSION_ID by 10000 and 100 using `as int`.
+HHAST divides your HHVM\_VERSION\_ID by 10000 and 100 using `as int`.
 Use `\intdiv()` or `Math\int_div()` like so.
 ```
 "AST version mismatch: expected '%s' (%d.%d.%d), but got '%s",

--- a/DEVELOPERNOTES.md
+++ b/DEVELOPERNOTES.md
@@ -1,0 +1,71 @@
+## Heads-up
+
+The library requires hhvm 3.30 and will therefore use hhvm-autoload 1.
+This version ought to be run with HHVM, not PHP.
+Failing to do so will result in this error:
+```
+Fatal error: Uncaught Error: Class undefined: Facebook\AutoloadMap\IncludedRoots in /.../quizlet/hammock/vendor/hhvm/hhvm-autoload/bin/hh-autoload:86
+```
+
+## Required patches to composer packages
+
+### Typechecker
+
+Composer requires two versions of the hsl and hsl-experimental that both define SecureRandom.
+Delete the file in /vendor/hhvm/hsl-experimetal/src/random/*.php
+
+In vendor/hhvm/hhast/src/__Private/LintRun.php
+HHAST checks the truthyness of a traversable, vec($errors) first on line 105, like so.
+```
+$errors = await $linter->getLintErrorsAsync();
+$errors = vec($errors);
+```
+
+In vendor/facebook/fbexpect/src/ExpectObj.php
+fbexpect toBePHPEqualWithNANEqual uses is_float, instead of `is float`, so is_nan() is a type error, use `is float` on line 83, like so.
+```
+is_float($expected) &&
+$actual is float &&
+\is_nan($expected) &&
+\is_nan($actual)
+```
+
+### Runtime
+
+In vendor/hhvm/hhast/src/SchemaVersionError.php
+HHAST divides your HHVM_VERSION_ID by 10000 and 100 using `as int`.
+Use `\intdiv()` or `Math\int_div()` like so.
+```
+"AST version mismatch: expected '%s' (%d.%d.%d), but got '%s",
+SCHEMA_VERSION,
+\intdiv(HHVM_VERSION_ID, 10000) as int,
+\intdiv(HHVM_VERSION_ID, 100) as int % 100,
+HHVM_VERSION_ID % 100,
+$version,
+```
+
+In vendor/hhvm/hhast/src/entrypoints.php
+HHAST Checks your AST version and throws this error:
+```
+A linter threw an exception:
+Linter: Facebook\HHAST\Linters\AsyncFunctionAndMethodLinter
+File: /.../quizlet/hammock/src/Persistent/PersistentMockRegistry.php
+Exception: Facebook\HHAST\SchemaVersionError
+Message: In file "! no file !": AST version mismatch: expected '2018-07-19-0001' (3.28.1), but got '2018-10-30-0001
+Trace:
+  #0 /.../quizlet/hammock/vendor/hhvm/hhast/src/entrypoints.php(124): Facebook\HHAST\from_json()
+  #1 /.../quizlet/hammock/vendor/hhvm/hhast/src/Linters/ASTLinter.php(30): Facebook\HHAST\from_code_async()
+  ...
+  #16 /.../quizlet/hammock/vendor/hhvm/hhast/bin/hhast-lint(36): Facebook\CLILib\CLIBase::main()
+  #17 {main}
+```
+
+Comment out line 21 like so.
+```
+// throw new SchemaVersionError($file ?? '! no file !', $version);
+```
+
+## Configuration
+
+HHAST will have some issues with parsing, so DON'T blindly run hhast.
+The autofixes it presents are not safe.

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     },
     "require-dev": {
         "facebook/fbexpect": "1.1",
-        "hhvm/hacktest": "1.2"
+        "hhvm/hacktest": "1.2",
+        "hhvm/hhast": "^3.27"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b626862d54b873d2d3010155e3be0bec",
+    "content-hash": "db39649463f6336bc512711a0a032ce3",
     "packages": [
         {
             "name": "facebook/hh-clilib",
@@ -308,6 +308,40 @@
             "time": "2019-10-21T16:45:58+00:00"
         },
         {
+            "name": "facebook/difflib",
+            "version": "v1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hhvm/difflib.git",
+                "reference": "09505c7d66224fa7e5a8f775825bd70f05e57b01"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hhvm/difflib/zipball/09505c7d66224fa7e5a8f775825bd70f05e57b01",
+                "reference": "09505c7d66224fa7e5a8f775825bd70f05e57b01",
+                "shasum": ""
+            },
+            "require": {
+                "hhvm/hsl": "^3.28"
+            },
+            "require-dev": {
+                "facebook/fbexpect": "^2.1.2",
+                "hhvm/hacktest": "^1.0",
+                "hhvm/hhast": "^3.28"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.2.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "time": "2018-09-24T22:01:02+00:00"
+        },
+        {
             "name": "facebook/fbexpect",
             "version": "v1.1.0",
             "source": {
@@ -378,6 +412,49 @@
             ],
             "description": "The Hack Test Library",
             "time": "2018-10-17T22:18:04+00:00"
+        },
+        {
+            "name": "hhvm/hhast",
+            "version": "v3.28.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hhvm/hhast.git",
+                "reference": "81a4812cc67ea60ea46c010163218d2149652057"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hhvm/hhast/zipball/81a4812cc67ea60ea46c010163218d2149652057",
+                "reference": "81a4812cc67ea60ea46c010163218d2149652057",
+                "shasum": ""
+            },
+            "require": {
+                "facebook/difflib": "^1.0.0",
+                "facebook/hh-clilib": "^1.1.1",
+                "hhvm": "^3.28.0",
+                "hhvm/hsl": "^1.0.0|^3.26.0",
+                "hhvm/type-assert": "^3.1"
+            },
+            "require-dev": {
+                "facebook/fbexpect": "^2.1.1",
+                "facebook/hack-codegen": "~3.2.1",
+                "hhvm/hacktest": "^1.0",
+                "hhvm/hhvm-autoload": "^1.5"
+            },
+            "bin": [
+                "bin/hhast-lint",
+                "bin/hhast-inspect"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "time": "2018-10-05T16:46:16+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1546,16 +1623,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
                 "shasum": ""
             },
             "require": {
@@ -1567,7 +1644,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -1600,11 +1677,11 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.4.0",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",

--- a/hh_autoload.json
+++ b/hh_autoload.json
@@ -3,11 +3,7 @@
         "src/"
     ],
     "devRoots": [
-        "tests/",
-        "vendor/composer/facebook/",
-        "vendor/composer/hhvm/",
-        "vendor/composer/phpunit/",
-        "vendor/composer/sebastian/exporter/"
+        "tests/"
     ],
     "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler"
 }

--- a/hhast-lint.json
+++ b/hhast-lint.json
@@ -1,0 +1,5 @@
+{
+  "roots": [ "src/", "tests/" ],
+  "builtinLinters": "all",
+  "disableAllAutoFixes": true
+}

--- a/src/MockManager.php
+++ b/src/MockManager.php
@@ -305,6 +305,8 @@ class MockManager {
 		string $mockKey,
 		self::InternalMockCallback $callback,
 	): void {
+    /* HH_FIXME[2049] This function is not in any hhi */
+    /* HH_FIXME[4107] This function is not in any hhi */
 		\fb_intercept(
 			$mockKey,
 			function(
@@ -313,6 +315,7 @@ class MockManager {
 				array<mixed> $args,
 				self::InternalMockCallback $cb,
 				/* HH_IGNORE_ERROR[1002] */
+        /* HH_FIXME[2087] Don't use references!*/
 				bool &$done,
 			): mixed {
 				// NOTE: The following 3 ignores should be unnecessary, but the
@@ -343,6 +346,8 @@ class MockManager {
 	}
 
 	protected static function unmock(string $mockKey): void {
+    /* HH_FIXME[2049] This function is not in any hhi. */
+    /* HH_FIXME[4107] This function is not in any hhi. */
 		\fb_intercept($mockKey, null);
 	}
 


### PR DESCRIPTION
I know that the indents don't line up.
This has to do with the fact that this repo does not use hackfmt.
I can't use _format on save_ and I can't indent things properly, since vscode hides the real indents from me.