### PR TITLE
Ignore tests in composer package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-test/ export-ignore
+tests/ export-ignore
 .hhconfig export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+test/ export-ignore
+.hhconfig export-ignore


### PR DESCRIPTION
Installing the package would cause typechecker errors.
The package depended on hacktest and fbexpect, because of the tests.

Fixes #10