### PR TITLE
Cheat on the composer dependency tests

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -10,7 +10,7 @@ php --version
   curl https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 )
 
-canruntests=$(hhvm --php -r "echo HHVM_VERSION_ID < 32800 ? 'yes' : 'no';")
+canruntests=$(hhvm --php -r "echo HHVM_VERSION_ID >= 32800 ? 'yes' : 'no';")
 if [ "$canruntests" = "yes" ]; then
   rm composer.json
   mv composer.development.json composer.json

--- a/.travis.sh
+++ b/.travis.sh
@@ -10,15 +10,15 @@ php --version
   curl https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 )
 
-removetestfiles=$(hhvm --php -r "echo HHVM_VERSION_ID < 32800 ? 'yes' : 'no';")
-if [ "$removetestfiles" = "yes" ]; then
+canruntests=$(hhvm --php -r "echo HHVM_VERSION_ID < 32800 ? 'yes' : 'no';")
+if [ "$canruntests" = "yes" ]; then
+  rm composer.json
+  mv composer.development.json composer.json
+else
   # The tests won't typecheck and work, so I remove them.
   rm -r tests
   # hhvm-autoload needs to have a directory here, but it can be empty.
   mkdir tests
-else
-  rm composer.json
-  mv composer.development.json composer.json
 fi
 
 runtime=$(hhvm --php -r "echo HHVM_VERSION_ID >= 40000 ? 'php' : 'hhvm';")
@@ -31,7 +31,6 @@ fi
 
 hh_client
 
-runstests=$(hhvm --php -r "echo HHVM_VERSION_ID >= 32800 ? 'canruntests' : 'cannotruntests';")
-if [ "$runstests" = "canruntests" ]; then
+if [ "$canruntests" = "yes" ]; then
   vendor/bin/hacktest tests/
 fi

--- a/.travis.sh
+++ b/.travis.sh
@@ -12,10 +12,10 @@ php --version
 
 removetestfiles=$(hhvm --php -r "echo HHVM_VERSION_ID < 32800 ? 'yes' : 'no';")
 if [ "$removetestfiles" = "yes" ]; then
-	# The tests won't typecheck and work, so I remove them.
-	rm -r tests
-	# hhvm-autoload needs to have a directory here, but it can be empty.
-	mkdir tests
+  # The tests won't typecheck and work, so I remove them.
+  rm -r tests
+  # hhvm-autoload needs to have a directory here, but it can be empty.
+  mkdir tests
 else
   rm composer.json
   mv composer.development.json composer.json

--- a/.travis.sh
+++ b/.travis.sh
@@ -10,18 +10,19 @@ php --version
   curl https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 )
 
+removetestfiles=$(hhvm --php -r "echo HHVM_VERSION_ID < 32800 ? 'yes' : 'no';")
+if [ "$removetestfiles" = "yes" ]; then
+	# The tests won't typecheck and work, so I remove them.
+	rm -r tests
+	# hhvm-autoload needs to have a directory here, but it can be empty.
+	mkdir tests
+else
+  rm composer.json
+  mv composer.development.json composer.json
+fi
+
 runtime=$(hhvm --php -r "echo HHVM_VERSION_ID >= 40000 ? 'php' : 'hhvm';")
 if [ "$runtime" = "hhvm" ]; then
-  removetestfiles=$(hhvm --php -r "echo HHVM_VERSION_ID < 32800 ? 'yes' : 'no';")
-  if [ "$removetestfiles" = "yes" ]; then
-    # The tests won't typecheck and work, so I remove them.
-    rm -r tests
-    # hhvm-autoload needs to have a directory here, but it can be empty.
-    mkdir tests
-    # We can't install hacktest
-    rm composer.json
-    mv composer.old.json composer.json
-  fi
   hhvm /usr/local/bin/composer install
 else
   # Implicitly uses php

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,12 @@
 We welcome all sorts of contributions. Please first discuss the change you wish to make via issue, email, or any other method with the owners of this repository before making a change.
 
 ## Code and Documentation
+
 1. Fork the [repository](https://github.com/quizlet/hammock) on GitHub.
 2. Add the code and tests. If possible, link it to an issue.
 3. Update [README.md](https://github.com/quizlet/hammock/blob/master/README.md) with the details of your changes.
 4. Send a Pull Request to the `master` branch.
 
 Any code you contribute must also follow the [MIT license](https://github.com/quizlet/hammock/blob/master/LICENSE).
+
+You'll find some important steps in [the developer notes](DEVELOPERNOTES.md)

--- a/DEVELOPERNOTES.md
+++ b/DEVELOPERNOTES.md
@@ -3,6 +3,17 @@
 The library requires hhvm 3.30 and will therefore use hhvm-autoload 1.
 This version ought to be run with HHVM, not PHP.
 Failing to do so will result in this error:
+
 ```
 Fatal error: Uncaught Error: Class undefined: Facebook\AutoloadMap\IncludedRoots in /.../quizlet/hammock/vendor/hhvm/hhvm-autoload/bin/hh-autoload:86
 ```
+
+### For developing on hammock
+
+If you want to develop (and test) hammock, you are going to need two things.
+
+- hhvm 3.28 or greater, since hacktest doesn't work on hhvm 3.27 and below
+- remove composer.json and rename composer.development.json to composer.json
+
+The last one shouldn't be needed, but composer wants you to be able to install the dev deps when you use the library.
+Even when you don't want / need the tests.

--- a/composer.development.json
+++ b/composer.development.json
@@ -15,7 +15,7 @@
     "require": {
         "hhvm": ">=3.24",
         "hhvm/hhvm-autoload": "^1|^2|^3",
-        "hhvm/hsl": ">1.4 <5"
+        "hhvm/hsl": ">=1.4 <5"
     },
     "require-dev": {
         "facebook/fbexpect": ">=2",

--- a/composer.development.json
+++ b/composer.development.json
@@ -16,5 +16,10 @@
         "hhvm": ">=3.24",
         "hhvm/hhvm-autoload": "^1|^2|^3",
         "hhvm/hsl": ">1.4 <5"
+    },
+    "require-dev": {
+        "facebook/fbexpect": ">=2",
+        "hhvm/hacktest": ">=1.2",
+        "hhvm/hhast": ">=3.27"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
     "require": {
         "hhvm": ">=3.24",
         "hhvm/hhvm-autoload": "^1|^2|^3",
-        "hhvm/hsl": ">1.4 <5"
+        "hhvm/hsl": ">=1.4 <5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,5 @@
         "hhvm": ">=3.24",
         "hhvm/hhvm-autoload": "^1|^2|^3",
         "hhvm/hsl": ">1.4 <5"
-    },
-    "require-dev": {
-        "facebook/fbexpect": ">=2",
-        "hhvm/hacktest": ">=1.2",
-        "hhvm/hhast": ">=3.27"
     }
 }


### PR DESCRIPTION
Composer wants you to be able to install the dev deps.
Even if you don't need / use them.
--no-dev specifically states this in a warning message.

Since hacktest is not supported on hhvm 3.25, we need to remove it from composer.json

Also fixes some off-by-one errors in the version numbers I got from quizlet.