### PR TITLE
Add isDeactivated() to IDeactivatable

### DIFF
--- a/src/Interfaces/IDeactivatable.php
+++ b/src/Interfaces/IDeactivatable.php
@@ -4,4 +4,5 @@ namespace Hammock\Interfaces;
 
 interface IDeactivatable {
 	public function deactivate(): void;
+	public function isDeactivated(): bool;
 }

--- a/src/Persistent/Mocks/PersistentFunctionMock.php
+++ b/src/Persistent/Mocks/PersistentFunctionMock.php
@@ -52,6 +52,10 @@ abstract class PersistentFunctionMock implements IFunctionMock, IDeactivatable {
 		$this->isDeactivated = true;
 	}
 
+	public function isDeactivated(): bool {
+		return $this->isDeactivated;
+	}
+
 	protected function throwIfDeactivated(): void {
 		if ($this->isDeactivated) {
 			throw new HammockException(

--- a/src/Persistent/Mocks/PersistentMethodMockContainer.php
+++ b/src/Persistent/Mocks/PersistentMethodMockContainer.php
@@ -59,4 +59,8 @@ abstract class PersistentMethodMockContainer
 
 		$this->methodMocks = dict[];
 	}
+
+	public function isDeactivated(): bool {
+		return $this->isDeactivated;
+	}
 }


### PR DESCRIPTION
This adds an `isDeactivated` method on the `IDeactivatable` interface, which takes no arguments and returns a boolean.

This also adds an `isDeactivated` implementation to all implementing classes of `IDeactivatable`, which both already had a bool field called `isDeactivated`, so this method just returns that value of that field.

Closes #19 