### PR TITLE
PersistentMockRegistry: Prune deactivated PersistentMocks after reaching a soft limit

### DIFF
--- a/src/Persistent/PersistentMockRegistry.php
+++ b/src/Persistent/PersistentMockRegistry.php
@@ -7,16 +7,25 @@ use type Hammock\Interfaces\IDeactivatable;
 
 class PersistentMockRegistry {
 	const REGISTRY_SOFT_LIMIT = 100;
+	const PRUNE_INTERVAL = 10;
 	protected static vec<IDeactivatable> $registry = vec[];
+	protected static int $pruneAttempts = 0;
 
 	public static function register(IDeactivatable $persistentMock): void {
-		// When the registry grows beyond REGISTRY_SOFT_LIMIT size,
-		// we prune the registry by removing persistent mocks
-		// that have been manually deactivated.
 		self::$registry[] = $persistentMock;
 
-		if (C\count(self::$registry) >= self::REGISTRY_SOFT_LIMIT) {
+		// When the registry grows beyond REGISTRY_SOFT_LIMIT size,
+		// we prune the registry every PRUNE_INTERVAL calls to register
+		// by removing persistent mocks that have been manually deactivated.
+		//
+		// If the number of items in the registry drops below REGISTRY_SOFT_LIMIT,
+		// the number of attempts is reset to zero.
+		if (C\count(self::$registry) >= self::REGISTRY_SOFT_LIMIT &&
+			  self::$pruneAttempts % self::PRUNE_INTERVAL == 0) {
 			self::$registry = Vec\filter(self::$registry, $mock ==> !$mock->isDeactivated());
+			self::$pruneAttempts += 1;
+		} else {
+			self::$pruneAttempts = 0;
 		}
 	}
 

--- a/src/Persistent/PersistentMockRegistry.php
+++ b/src/Persistent/PersistentMockRegistry.php
@@ -6,8 +6,8 @@ use namespace HH\Lib\{C, Vec};
 use type Hammock\Interfaces\IDeactivatable;
 
 class PersistentMockRegistry {
-	const REGISTRY_SOFT_LIMIT = 100;
-	const PRUNE_INTERVAL = 10;
+	const int REGISTRY_SOFT_LIMIT = 100;
+	const int PRUNE_INTERVAL = 10;
 	protected static vec<IDeactivatable> $registry = vec[];
 	protected static int $pruneAttempts = 0;
 

--- a/src/Persistent/PersistentMockRegistry.php
+++ b/src/Persistent/PersistentMockRegistry.php
@@ -2,17 +2,22 @@
 
 namespace Hammock\Persistent;
 
+use namespace HH\Lib\{C, Vec};
 use type Hammock\Interfaces\IDeactivatable;
 
 class PersistentMockRegistry {
+	const REGISTRY_SOFT_LIMIT = 100;
 	protected static vec<IDeactivatable> $registry = vec[];
 
 	public static function register(IDeactivatable $persistentMock): void {
-		// NOTE: When the registry grows beyond a certain threshold,
-		// we can prune the registry by removing persistent mocks
-		// that have been manually deactivated. This will require
-		// an `isDeactivated` interface on `IDeactivatable`.
+		// When the registry grows beyond REGISTRY_SOFT_LIMIT size,
+		// we prune the registry by removing persistent mocks
+		// that have been manually deactivated.
 		self::$registry[] = $persistentMock;
+
+		if (C\count(self::$registry) >= self::REGISTRY_SOFT_LIMIT) {
+			self::$registry = Vec\filter(self::$registry, $mock ==> !$mock->isDeactivated());
+		}
 	}
 
 	public static function deactivateAllPersistentMocks(): void {

--- a/src/Persistent/PersistentMockRegistry.php
+++ b/src/Persistent/PersistentMockRegistry.php
@@ -20,9 +20,11 @@ class PersistentMockRegistry {
 		//
 		// If the number of items in the registry drops below REGISTRY_SOFT_LIMIT,
 		// the number of attempts is reset to zero.
-		if (C\count(self::$registry) >= self::REGISTRY_SOFT_LIMIT &&
-			  self::$pruneAttempts % self::PRUNE_INTERVAL == 0) {
-			self::$registry = Vec\filter(self::$registry, $mock ==> !$mock->isDeactivated());
+		if (C\count(self::$registry) >= self::REGISTRY_SOFT_LIMIT) {
+			if (self::$pruneAttempts % self::PRUNE_INTERVAL == 0) {
+				self::$registry = Vec\filter(self::$registry, $mock ==> !$mock->isDeactivated());
+			}
+
 			self::$pruneAttempts += 1;
 		} else {
 			self::$pruneAttempts = 0;

--- a/tests/Fixtures/MockDeactivatable.php
+++ b/tests/Fixtures/MockDeactivatable.php
@@ -1,0 +1,15 @@
+<?hh // strict
+
+namespace Hammock\Fixtures;
+
+use type Hammock\Interfaces\IDeactivatable;
+
+class MockDeactivatable implements IDeactivatable {
+	private bool $isDeactivated = false;
+	public function deactivate(): void {
+		$this->isDeactivated = true;
+	}
+	public function isDeactivated(): bool {
+		return $this->isDeactivated;
+	}
+}

--- a/tests/Fixtures/MockPersistentMockRegistry.php
+++ b/tests/Fixtures/MockPersistentMockRegistry.php
@@ -1,0 +1,12 @@
+<?hh // strict
+
+namespace Hammock\Fixtures;
+
+use type Hammock\Interfaces\IDeactivatable;
+use type Hammock\Persistent\PersistentMockRegistry;
+
+class MockPersistentMockRegistry extends PersistentMockRegistry {
+	public static function getRegistry(): vec<IDeactivatable> {
+		return self::$registry;
+	}
+}

--- a/tests/PersistentTest.php
+++ b/tests/PersistentTest.php
@@ -4,7 +4,7 @@ namespace Hammock;
 
 use type Facebook\HackTest\HackTest;
 use type Hammock\Exceptions\HammockException;
-use type Hammock\Fixtures\{ChildClass, TestClass};
+use type Hammock\Fixtures\{ChildClass, TestClass, MockDeactivatable, MockPersistentMockRegistry};
 use type Hammock\Persistent\Mocks\{PersistentFunctionMock};
 use function Facebook\FBExpect\expect;
 use function Hammock\Fixtures\return_input;
@@ -392,21 +392,5 @@ class PersistentTest extends HackTest {
 
 	private function noopGlobalFunction(): PersistentFunctionMock {
 		return Persistent\noop_global_function('Hammock\Fixtures\return_input');
-	}
-}
-
-class MockPersistentMockRegistry extends Persistent\PersistentMockRegistry {
-	public static function getRegistry(): vec<Interfaces\IDeactivatable> {
-		return self::$registry;
-	}
-}
-
-class MockDeactivatable implements Interfaces\IDeactivatable {
-	private bool $isDeactivated = false;
-	public function deactivate(): void {
-		$this->isDeactivated = true;
-	}
-	public function isDeactivated(): bool {
-		return $this->isDeactivated;
 	}
 }


### PR DESCRIPTION
This adds functionality to remove deactivated persistent mocks
from the PersistentMockRegistry once the number of registered
mocks exceeds REGISTRY_SOFT_LIMIT (in this case 100).