### PR TITLE
Support hhvm 4.69+

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -1,2 +1,4 @@
 assume_php = true
 hackfmt.tabs = true
+allowed_decl_fixme_codes=2053,4047
+allowed_fixme_codes_strict=2011,2049,2050,2053,4009,4027,4047,4104,4107,4108,4110,4128,4135,4188,4240,4323

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ env:
 - HHVM_VERSION=4.32-latest
 - HHVM_VERSION=4.40-latest
 - HHVM_VERSION=4.48-latest
+- HHVM_VERSION=4.56-latest
+- HHVM_VERSION=4.64-latest
+# version 4.70 was skipped, testing on hhvm 4.49 instead
+- HHVM_VERSION=4.69-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 - HHVM_VERSION=4.48-latest
 - HHVM_VERSION=4.56-latest
 - HHVM_VERSION=4.64-latest
-# version 4.70 was skipped, testing on hhvm 4.49 instead
+# version 4.70 was skipped, testing on hhvm 4.69 instead
 - HHVM_VERSION=4.69-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly

--- a/src/MockManager.php
+++ b/src/MockManager.php
@@ -336,7 +336,7 @@ class MockManager {
 			(
 				string $_,
 				mixed $objectOrString,
-				array<mixed> $args,
+				varray<mixed> $args,
 				mixed $cb,
 				Ref<bool> $done,
 			): mixed ==> {


### PR DESCRIPTION
Hhvm [4.62](https://hhvm.com/blog/2020/06/16/hhvm-4.62.html) introduced the requirements for whitelisting your hh_fixmes.
This didn't break for dependents, only when hammock is typechecked in isolation.

Hhvm [4.68](https://hhvm.com/blog/2020/07/30/hhvm-4.68.html) removed the `array<_>` and `array<_, _>` typehints.
Use `varray<_>` and `darray<_, _>` instead for maximum compatibility.
HEADS-UP: In older hhvm versions, (d/v)arrayness was not checked at runtime and never versions will error on typehint mismatches.